### PR TITLE
fix std::bind compilation error

### DIFF
--- a/tests/latchMain.cpp
+++ b/tests/latchMain.cpp
@@ -15,6 +15,7 @@
 #include <iostream>
 #include <vector>
 #include <chrono>
+#include <functional>
 #include "rtb/concurrency/Latch.h"
 
 std::mutex mutexOutput; 

--- a/tests/queueMain.cpp
+++ b/tests/queueMain.cpp
@@ -15,6 +15,7 @@
 #include "threadFunctions.h"
 #include <iostream>
 #include <vector>
+#include <functional>
 
 using namespace rtb::Concurrency;
 


### PR DESCRIPTION
Fix missing inclusion of <functional> causing compilation error.